### PR TITLE
Reduce CPU load of menu

### DIFF
--- a/src/main/java/tetris/gui/Tetris.java
+++ b/src/main/java/tetris/gui/Tetris.java
@@ -74,10 +74,10 @@ public class Tetris extends Canvas {
                 if (keyboard.pauseGame()) {
                     game.pauseGame();
                 }
-                try {
-                    Thread.sleep(20);
-                } catch (Exception e) { }
             }
+            try {
+                Thread.sleep(20);
+            } catch (Exception e) { }
             draw();
         }
     }


### PR DESCRIPTION
Moved the 20ms sleep outside of the playing condition, since it was
causing the CPU to run 100% on one core.